### PR TITLE
perf: remove unnecessary lock

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Test
         run: |
-          go test -count=50 -v ./... -covermode=count -coverprofile=coverage.out
+          go test -count=100 -timeout=1800s -v ./... -covermode=count -coverprofile=coverage.out
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/executor.go
+++ b/executor.go
@@ -116,10 +116,7 @@ func (e *innerExecutorImpl) invokeStatic(node *innerNode, parentSpan *span, p *S
 
 			node.drop()
 			e.sche_successors(node)
-			node.g.scheCond.L.Lock()
 			node.g.deref()
-			node.g.scheCond.Signal()
-			node.g.scheCond.L.Unlock()
 			e.wg.Done()
 		}()
 		if !node.g.canceled.Load() {
@@ -151,12 +148,7 @@ func (e *innerExecutorImpl) invokeSubflow(node *innerNode, parentSpan *span, p *
 			e.scheduleGraph(node.g, p.g, &span)
 			node.drop()
 			e.sche_successors(node)
-
-			node.g.scheCond.L.Lock()
 			node.g.deref()
-			node.g.scheCond.Signal()
-			node.g.scheCond.L.Unlock()
-
 			e.wg.Done()
 		}()
 
@@ -189,11 +181,7 @@ func (e *innerExecutorImpl) invokeCondition(node *innerNode, parentSpan *span, p
 			}
 			node.drop()
 			// e.sche_successors(node)
-			node.g.scheCond.L.Lock()
 			node.g.deref()
-			node.g.scheCond.Signal()
-			node.g.scheCond.L.Unlock()
-
 			node.setup()
 			e.wg.Done()
 		}()

--- a/graph.go
+++ b/graph.go
@@ -35,12 +35,15 @@ func (g *eGraph) ref() {
 }
 
 func (g *eGraph) deref() {
+	g.scheCond.L.Lock()
+	defer g.scheCond.L.Unlock()
+	defer g.scheCond.Signal()
+
 	g.rw.Lock()
 	defer g.rw.Unlock()
 	if g.joinCounter == 0 {
 		panic(fmt.Sprintf("graph %v ref counter is zero, cannot deref", g.name))
 	}
-
 	g.joinCounter--
 }
 
@@ -48,7 +51,7 @@ func (g *eGraph) reset() {
 	g.joinCounter = 0
 	g.entries = g.entries[:0]
 	for _, n := range g.nodes {
-		n.joinCounter = 0
+		n.joinCounter.Store(0)
 	}
 }
 


### PR DESCRIPTION
Since RC ref strictly happens before deref, while tasks are scheduling and executing, and go mem order is the same as seq, so that the locks can be removed.

https://go.dev/ref/mem#atomic

