### PR TITLE
optimize(api): make condition task precede more user-friendly

### DIFF
--- a/task.go
+++ b/task.go
@@ -9,8 +9,9 @@ type Task struct {
 // In Addition, order of tasks is correspond to predict result, ranging from 0...len(tasks)
 func (t *Task) Precede(tasks ...*Task) {
 	if cond, ok := t.node.ptr.(*Condition); ok {
-		for i, task := range tasks {
-			cond.mapper[uint(i)] = task.node
+		for _, task := range tasks {
+			index := len(cond.mapper)
+			cond.mapper[uint(index)] = task.node
 		}
 	}
 

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -380,6 +380,58 @@ func TestTaskflowCondition(t *testing.T) {
 
 	})
 
+	t.Run("normal-1", func(t *testing.T) {
+		tf := gotaskflow.NewTaskFlow("G")
+
+		A, B, C :=
+			tf.NewTask("A", func() {
+				fmt.Println("A")
+				q.Put("A")
+			}),
+			tf.NewTask("B", func() {
+				fmt.Println("B")
+				q.Put("B")
+			}),
+			tf.NewTask("C", func() {
+				fmt.Println("C")
+				q.Put("C")
+			})
+		A.Precede(B)
+		C.Precede(B)
+
+		fail, success := tf.NewTask("failed", func() {
+			fmt.Println("Failed")
+			q.Put("failed")
+			t.Fail()
+		}), tf.NewTask("success", func() {
+			fmt.Println("success")
+			q.Put("success")
+		})
+
+		cond := tf.NewCondition("cond", func() uint {
+			q.Put("cond")
+			return 0
+		})
+		B.Precede(cond)
+		cond.Precede(success)
+		cond.Precede(fail)
+
+		// success.Precede(suc)
+		if err := tf.Dump(os.Stdout); err != nil {
+			fmt.Errorf("%v", err)
+		}
+		executor.Run(tf).Wait()
+
+		executor.Profile(os.Stdout)
+		chain.grouping("A", "C")
+		chain.grouping("B")
+		chain.grouping("cond")
+		chain.grouping("success")
+
+		checkTopology(t, q, chain)
+
+	})
+
 	t.Run("start with condition node", func(t *testing.T) {
 		i := 0
 		tf := gotaskflow.NewTaskFlow("G")


### PR DESCRIPTION
Optimize ConditionTask.Precede by replacing i with len(cond.mapper) to resolve abnormal flow execution results caused by multiple calls to precede